### PR TITLE
add ability to get current snapshot from snapshot/name endpoint

### DIFF
--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -1778,8 +1778,13 @@ class SnapshotList(JsonRequestHandler):
 
 class SnapshotName(JsonRequestHandler):
     def get(self):
-        idx  = int(self.get_argument('id'))
-        name = SESSION.host.snapshot_name(idx) or DEFAULT_SNAPSHOT_NAME
+        arg = self.get_argument('id')
+        name = ""
+        if arg == "current":
+            name = SESSION.host.snapshot_name()
+        else:
+            idx  = int(arg)
+            name = SESSION.host.snapshot_name(idx) or DEFAULT_SNAPSHOT_NAME
         self.write({
             'ok'  : bool(name),
             'name': name


### PR DESCRIPTION
This will allow obtaining the current snapshot info:
curl localhost/snapshot/name?id=current

where before the endpoint would return the info for a specified id only:
curl localhost/snapshot/name?id=3

