### PR TITLE
fix lockup when loading a snapshot which doesn't include bpm or bpb

### DIFF
--- a/mod/host.py
+++ b/mod/host.py
@@ -3141,8 +3141,11 @@ class Host(object):
             diffBypass = (self.should_save_addressing_value(addressing, pluginData['bypassed']) and
                           pluginData['bypassed'] != data['bypassed'])
             diffPreset = data['preset'] and data['preset'] != pluginData['preset']
-            diffBpm = data['bpm'] and data['bpm'] != self.transport_bpm
-            diffBpb = data['bpb'] and data['bpb'] != self.transport_bpb
+
+            bpm = data.get('bpm')
+            diffBpm = bpm is not None and bpm != self.transport_bpm
+            bpb = data.get('bpb')
+            diffBpb = bpb is not None and bpb != self.transport_bpb
 
             if was_aborted or diffBypass:
                 if addressing is not None:

--- a/mod/host.py
+++ b/mod/host.py
@@ -3699,7 +3699,8 @@ class Host(object):
             self.pedalboard_path     = ""
             self.pedalboard_size     = [0,0]
             self.pedalboard_version  = 0
-            self.midi_aggregated_mode = True
+            # Don't override MIDI mode for default pedalboards - use the mode from the pedalboard
+            # self.midi_aggregated_mode = True
             #save_last_bank_and_pedalboard(0, "")
         else:
             self.pedalboard_empty    = False

--- a/mod/host.py
+++ b/mod/host.py
@@ -2739,7 +2739,10 @@ class Host(object):
     
     def pi_stomp_param_get(self, port):
         instance, symbol = port.rsplit("/", 1)
-        instance_id = self.mapper.get_id_without_creating(instance)
+        try:
+            instance_id = self.mapper.get_id_without_creating(instance)
+        except KeyError:
+            return None
         pluginData  = self.plugins[instance_id]
 
         if symbol == ":bypass":

--- a/mod/host.py
+++ b/mod/host.py
@@ -3055,8 +3055,7 @@ class Host(object):
         snapshot = self.snapshot_make(name)
         self.pedalboard_snapshots[idx] = snapshot
 
-        # Write snapshots to disk immediately so external tools (like piStomp blend mode)
-        # can detect the change and update their state
+        # Write snapshots to disk immediately so external tools can detect the change
         if self.pedalboard_path:
             self.save_state_snapshots(self.pedalboard_path)
 

--- a/mod/host.py
+++ b/mod/host.py
@@ -3054,6 +3054,12 @@ class Host(object):
         name     = self.pedalboard_snapshots[idx]['name']
         snapshot = self.snapshot_make(name)
         self.pedalboard_snapshots[idx] = snapshot
+
+        # Write snapshots to disk immediately so external tools (like piStomp blend mode)
+        # can detect the change and update their state
+        if self.pedalboard_path:
+            self.save_state_snapshots(self.pedalboard_path)
+
         return True
 
     def snapshot_saveas(self, name):

--- a/mod/host.py
+++ b/mod/host.py
@@ -3182,18 +3182,21 @@ class Host(object):
                     logging.exception(e)
 
             if was_aborted or diffPreset:
+                # Always load the preset if it changed
+                if diffPreset:
+                    self.msg_callback("preset %s %s" % (instance, data['preset']))
+                    try:
+                        yield gen.Task(self.preset_load_gen_helper, instance, data['preset'], from_hmi, abort_catcher)
+                    except Exception as e:
+                        logging.exception(e)
+
+                # Update addressing if preset is mapped to hardware
                 try:
                     index = pluginData['mapPresets'].index(data['preset'])
                 except ValueError:
+                    # Preset not in mapPresets, no hardware addressing to update
                     pass
                 else:
-                    if diffPreset:
-                        self.msg_callback("preset %s %s" % (instance, data['preset']))
-                        try:
-                            yield gen.Task(self.preset_load_gen_helper, instance, data['preset'], from_hmi, abort_catcher)
-                        except Exception as e:
-                            logging.exception(e)
-
                     addressing = pluginData['addressings'].get(":presets", None)
                     if addressing is not None:
                         addressing['value'] = index

--- a/mod/host.py
+++ b/mod/host.py
@@ -2696,7 +2696,13 @@ class Host(object):
     def param_set(self, port, value, callback):
         instance, symbol = port.rsplit("/", 1)
         instance_id = self.mapper.get_id_without_creating(instance)
-        pluginData  = self.plugins[instance_id]
+
+        try:
+            pluginData = self.plugins[instance_id]
+        except KeyError:
+            if callback is not None:
+                callback(False)
+            return
 
         if symbol in pluginData['designations']:
             print("ERROR: Trying to modify a specially designated port '%s', stop!" % symbol)
@@ -2714,8 +2720,15 @@ class Host(object):
 
     def patch_set(self, instance, paramuri, value, callback):
         instance_id = self.mapper.get_id_without_creating(instance)
-        pluginData  = self.plugins[instance_id]
-        parameter   = pluginData['parameters'].get(paramuri, None)
+
+        try:
+            pluginData = self.plugins[instance_id]
+        except KeyError:
+            if callback is not None:
+                callback(False)
+            return False
+
+        parameter = pluginData['parameters'].get(paramuri, None)
 
         if parameter is not None:
             parameter[0] = value

--- a/mod/screenshot.py
+++ b/mod/screenshot.py
@@ -4,6 +4,7 @@
 
 import os
 import subprocess
+import sys
 
 from tornado.ioloop import IOLoop
 from mod.settings import HTML_DIR, DEV_ENVIRONMENT, DEVICE_KEY, CACHE_DIR
@@ -20,7 +21,7 @@ def generate_screenshot(bundle_path, callback):
         pass
 
     cwd = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
-    cmd = ['python3', '-m', 'modtools.pedalboard', 'take_screenshot', bundle_path, HTML_DIR, CACHE_DIR]
+    cmd = [sys.executable, '-m', 'modtools.pedalboard', 'take_screenshot', bundle_path, HTML_DIR, CACHE_DIR]
     if not DEV_ENVIRONMENT and DEVICE_KEY:  # if using a real MOD, setup niceness
         cmd = ['/usr/bin/nice', '-n', '+34'] + cmd
 

--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -1740,6 +1740,9 @@ class SnapshotSaveAs(JsonRequestHandler):
 
         yield gen.Task(SESSION.host.hmi_report_ss_name_if_current, idx)
 
+        # Send WebSocket message to notify clients (e.g., pistomp) of the new snapshot
+        SESSION.host.msg_callback("pedal_snapshot %d %s" % (idx, title))
+
         self.write({
             'ok': idx is not None,
             'id': idx,

--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -1365,14 +1365,29 @@ class ServerWebSocket(websocket.WebSocketHandler):
         elif cmd == "transport-bpb":
             bpb = float(data[1])
             SESSION.host.set_transport_bpb(bpb, True, True, False, False)
+            SESSION.msg_callback_broadcast(
+                "transport %i %f %f %s" % (SESSION.host.transport_rolling,
+                                           SESSION.host.transport_bpb,
+                                           SESSION.host.transport_bpm,
+                                           SESSION.host.transport_sync), self)
 
         elif cmd == "transport-bpm":
             bpm = float(data[1])
             SESSION.host.set_transport_bpm(bpm, True, True, False, False)
+            SESSION.msg_callback_broadcast(
+                "transport %i %f %f %s" % (SESSION.host.transport_rolling,
+                                           SESSION.host.transport_bpb,
+                                           SESSION.host.transport_bpm,
+                                           SESSION.host.transport_sync), self)
 
         elif cmd == "transport-rolling":
             rolling = bool(int(data[1]))
             SESSION.host.set_transport_rolling(rolling, True, True, False, False)
+            SESSION.msg_callback_broadcast(
+                "transport %i %f %f %s" % (SESSION.host.transport_rolling,
+                                           SESSION.host.transport_bpb,
+                                           SESSION.host.transport_bpm,
+                                           SESSION.host.transport_sync), self)
 
         elif cmd == "show_external_ui":
             inst = data[1]


### PR DESCRIPTION
Changing snapshot to one which doesn't include bpm or bpb will cause mod-ui to fail (key error) and the pi-Stomp LCD will lockup.  The fix is to check the existence of the value in the array before using.